### PR TITLE
config.ini 更新

### DIFF
--- a/config.gen.ini
+++ b/config.gen.ini
@@ -15,5 +15,5 @@ prefix = !
 
 [redis]
 redis_host = localhost
-redis_port = "6379"
-redis_db = "14"
+redis_port = 6379
+redis_db = 14

--- a/config.gen.ini
+++ b/config.gen.ini
@@ -1,6 +1,6 @@
 [pyrogram]
-api_id = "ID_HERE"
-api_hash = "HASH_HERE"
+api_id = ID_HERE
+api_hash = HASH_HERE
 
 [plugins]
 root = modules


### PR DESCRIPTION
删除 config.ini 中 redis_port 和 redis_db 的引号以修复其引起的数据库未连接